### PR TITLE
change how ping-by-ping data are assembled into Dataset based on ping_time

### DIFF
--- a/echopype/convert/parse_base.py
+++ b/echopype/convert/parse_base.py
@@ -133,7 +133,7 @@ class ParseEK(ParseBase):
                 #  when users only want CONFIG or ENV, but the way this is implemented
                 #  the raw0/3 datagrams are still parsed, you are just not saving them
                 new_datagram = fid.read(1)
-                print(new_datagram['type'])
+
             except SimradEOF:
                 break
 
@@ -211,8 +211,8 @@ class ParseEK(ParseBase):
                 # Append ping by ping data
                 new_datagram.update(current_parameters)
                 self._append_channel_ping_data(new_datagram)
-                if self.n_complex_dict[curr_ch_id] < 0:   # TODO: @ngkvain: why test <0 ?
-                    self.n_complex_dict[curr_ch_id] = new_datagram['n_complex']  # update n_complex data
+                # if self.n_complex_dict[curr_ch_id] < 0:   # TODO: @ngkvain: why test <0 ?
+                #     self.n_complex_dict[curr_ch_id] = new_datagram['n_complex']  # update n_complex data
 
             # NME datagrams store ancillary data as NMEA-0817 style ASCII data.
             elif new_datagram['type'].startswith('NME'):
@@ -253,8 +253,8 @@ class ParseEK(ParseBase):
     def _append_channel_ping_data(self, datagram):
         """Append ping by ping data.
         """
-        unsaved = ['channel', 'channel_id', 'offset', 'low_date', 'high_date', 'frequency',
-                   'transmit_mode', 'spare0', 'bytes_read', 'type', 'n_complex']
+        unsaved = ['channel', 'channel_id', 'offset', 'low_date', 'high_date', #'frequency',
+                   'transmit_mode', 'spare0', 'bytes_read', 'type'] #, 'n_complex']
         ch_id = datagram['channel_id'] if 'channel_id' in datagram else datagram['channel']
         for k, v in datagram.items():
             if k not in unsaved:

--- a/echopype/convert/parse_base.py
+++ b/echopype/convert/parse_base.py
@@ -38,6 +38,7 @@ class ParseEK(ParseBase):
 
         # Class attributes
         self.config_datagram = None
+        self.ping_time = defaultdict(list)  # store ping time according to channel
         self.nmea_time = []
         self.raw_nmea_string = []
         self.ping_data_dict = defaultdict()  # dictionary to store metadata
@@ -132,6 +133,7 @@ class ParseEK(ParseBase):
                 #  when users only want CONFIG or ENV, but the way this is implemented
                 #  the raw0/3 datagrams are still parsed, you are just not saving them
                 new_datagram = fid.read(1)
+                print(new_datagram['type'])
             except SimradEOF:
                 break
 
@@ -156,6 +158,11 @@ class ParseEK(ParseBase):
                     current_parameters = new_datagram['parameter']
 
             # RAW0 datagrams store raw acoustic data for a channel for EK60
+            # TODO: change saving of RAW0 datagrams in the same way as RAW3 datagrams:
+            #   - keeping all the ping_time
+            #   - do not assume that all pings are transmitted simultaneously
+            #   - do not assume that the pings from different channels come in in a particular sequence.
+
             elif new_datagram['type'].startswith('RAW0'):
                 curr_ch_num = new_datagram['channel']
 
@@ -189,6 +196,7 @@ class ParseEK(ParseBase):
             # RAW3 datagrams store raw acoustic data for a channel for EK80
             elif new_datagram['type'].startswith('RAW3'):
                 curr_ch_id = new_datagram['channel_id']
+                # Check if the proceeding Parameter XML does not match with data in this RAW3 datagram
                 if current_parameters['channel_id'] != curr_ch_id:
                     raise ValueError("Parameter ID does not match RAW")
 
@@ -197,7 +205,8 @@ class ParseEK(ParseBase):
                     self.recorded_ch_ids.append(curr_ch_id)
 
                 # append ping time from first channel
-                self.ping_time.append(new_datagram['timestamp'])
+                # self.ping_time.append(new_datagram['timestamp'])
+                self.ping_time[curr_ch_id].append(new_datagram['timestamp'])
 
                 # Append ping by ping data
                 new_datagram.update(current_parameters)

--- a/echopype/convert/parse_ek80.py
+++ b/echopype/convert/parse_ek80.py
@@ -83,11 +83,11 @@ class ParseEK80(ParseEK):
             # TODO: @ngkavin: you are initializing attribute outside out __init__ and this should be done in ParseBase
             self.ping_data_dict = defaultdict(lambda: defaultdict(list))
 
-            for ch_id in self.ch_ids:
-                self.ping_data_dict['frequency'][ch_id].append(
-                    self.config_datagram['configuration'][ch_id]['transducer_frequency'])
-                # TODO: @ngkavin: what is this -1 for? you need to add an explicit comment if doing this
-                self.n_complex_dict[ch_id] = -1
+            # for ch_id in self.ch_ids:
+            #     self.ping_data_dict['frequency'][ch_id].append(
+            #         self.config_datagram['configuration'][ch_id]['transducer_frequency'])
+            #     # TODO: @ngkavin: what is this -1 for? you need to add an explicit comment if doing this
+            #     self.n_complex_dict[ch_id] = -1
 
             # Read the rest of datagrams
             self._read_datagrams(fid)

--- a/echopype/convert/parse_ek80.py
+++ b/echopype/convert/parse_ek80.py
@@ -77,17 +77,11 @@ class ParseEK80(ParseEK):
                 self._print_status()
 
             # IDs of the channels found in the dataset
-            self.ch_ids = list(self.config_datagram[self.config_datagram['subtype']])
+            self.ch_ids = list(self.config_datagram['configuration'].keys())
 
             # Parameters recorded for each frequency for each ping
             # TODO: @ngkavin: you are initializing attribute outside out __init__ and this should be done in ParseBase
             self.ping_data_dict = defaultdict(lambda: defaultdict(list))
-
-            # for ch_id in self.ch_ids:
-            #     self.ping_data_dict['frequency'][ch_id].append(
-            #         self.config_datagram['configuration'][ch_id]['transducer_frequency'])
-            #     # TODO: @ngkavin: what is this -1 for? you need to add an explicit comment if doing this
-            #     self.n_complex_dict[ch_id] = -1
 
             # Read the rest of datagrams
             self._read_datagrams(fid)

--- a/echopype/convert/parse_ek80.py
+++ b/echopype/convert/parse_ek80.py
@@ -27,6 +27,42 @@ class ParseEK80(ParseEK):
         self.sonar_type = 'EK80'
         self.data_type = self._select_datagrams(params)  # TODO: @ngkvain: you use this in ParseBase
 
+    @staticmethod
+    def pad_shorter_ping(data_list) -> np.ndarray:
+        """
+        Pad shorter ping with NaN: power, angle, complex samples.
+
+        Parameters
+        ----------
+        data_list : list
+            Power, angle, or complex samples for each channel from RAW3 datagram.
+            Each ping is one entry in the list.
+
+        Returns
+        -------
+        out_array : np.ndarray
+            Numpy array containing samplings from all pings.
+            The array is NaN-padded if some pings are of different lengths.
+        """
+        lens = np.array([len(item) for item in data_list])
+        if np.unique(lens).size != 1:  # if some pings have different lengths along range
+            if data_list[0].ndim == 2:
+                # Angle data have an extra dimension for alongship and athwartship samples
+                mask = lens[:, None, None] > np.array([np.arange(lens.max())] * 2).T
+            else:
+                mask = lens[:, None] > np.arange(lens.max())
+            # Take care of problem of np.nan being implicitly "real"
+            if isinstance(data_list[0][0], (np.complex, np.complex64, np.complex128)):
+                out_array = np.full(mask.shape, np.nan + 0j)
+            else:
+                out_array = np.full(mask.shape, np.nan)
+
+            # Fill in values
+            out_array[mask] = np.concatenate(data_list).reshape(-1)  # reshape in case data > 1D
+        else:
+            out_array = np.array(data_list)
+        return out_array
+
     def parse_raw(self):
         """Parse raw data file from Simrad EK80 echosounder.
         """
@@ -56,38 +92,28 @@ class ParseEK80(ParseEK):
             # Read the rest of datagrams
             self._read_datagrams(fid)
 
-            # Remove empty lists
-            # TODO: @ngkavin: I thought you would already handle this in _rectangularize()?
-            #  consolidate all code to clean up empty ping_data_dict
-            #  and also do the determiniation of cw and bb mode there.
-            for ch_id in self.ch_ids:
-                if all(x is None for x in self.ping_data_dict['power'][ch_id]):
-                    self.ping_data_dict['power'][ch_id] = None
-                    self.ping_data_dict['angle'][ch_id] = None
-                if all(x is None for x in self.ping_data_dict['complex'][ch_id]):
-                    self.ping_data_dict['complex'][ch_id] = None
-
         if 'ALL' in self.data_type:
-            self._clean_channel()  # TODO: @ngkavin: what does this do?
 
-            # TODO: @ngkavin: the next 2 lines can be removed
-            #  if you take the assembling a Dataset approach detailed in _rectangularize()
-            self.ping_time = np.unique(self.ping_time)
-            self._match_ch_ping_time()
+            # Convert ping time to 1D numpy array, stored in dict indexed by channel,
+            #  this will help merge data from all channels into a cube
+            for ch, val in self.ping_time.items():
+                self.ping_time[ch] = np.array(val)
+
+            # Rectangularize all data and convert to numpy array indexed by channel
+            for data_type in ['power', 'angle', 'complex']:
+                print(data_type)
+                for k, v in self.ping_data_dict[data_type].items():
+                    print(k)
+                    if all(x is None for x in v):  # if no data in a particular channel
+                        self.ping_data_dict[data_type][k] = None
+                    else:
+                        self.ping_data_dict[data_type][k] = self.pad_shorter_ping(v)
 
             # Save which channel ids are bb and which are ch because rectangularize() removes channel ids
             # TODO: @ngkavin:
             #  consolidate all code to clean up empty ping_data_dict
             #  and also do the determiniation of cw and bb mode there.
             self.bb_ch_ids, self.cw_ch_ids = self._sort_ch_bb_cw()
-
-            # TODO: @ngkavin: change _rectangularize() to handle only one type of data in an abstract form,
-            #  as there are no real differences in power, complex, or angle.
-            #  i.e. one call only rectangularizes power, complex, or angle.
-            #  The current structure trying to 1 or 2 of the 3 is confusing.
-            self.ping_data_dict['power'], self.ping_data_dict['angle'] = self._rectangularize(
-                self.ping_data_dict['power'], self.ping_data_dict['angle'])
-            self.ping_data_dict['complex'], _ = self._rectangularize(self.ping_data_dict['complex'])
 
             # TODO: @ngkavin: converting to numpy array should be done in the parent class
             #  since it's the same for both EK60 and EK80

--- a/echopype/convert/set_groups_base.py
+++ b/echopype/convert/set_groups_base.py
@@ -43,7 +43,10 @@ class SetGroupsBase:
         # date_created = dt.strptime(filedate + '-' + filetime, '%Y%m%d-%H%M%S').isoformat() + 'Z'
 
         # Collect variables
-        date_created = self.convert_obj.ping_time[0]
+        pt = []
+        for v in self.convert_obj.ping_time.values():
+            pt.append(v[0])
+        date_created = np.sort(pt)[0]
 
         tl_dict = {'conventions': 'CF-1.7, SONAR-netCDF4-1.0, ACDD-1.3',
                    'keywords': sonar_model,

--- a/echopype/convert/set_groups_ek80.py
+++ b/echopype/convert/set_groups_ek80.py
@@ -164,103 +164,31 @@ class SetGroupsEK80(SetGroupsBase):
         """Set the Beam group.
         """
         config = self.convert_obj.config_datagram['configuration']
-        freq = np.array([config[x]['transducer_frequency'] for x in ch_ids], dtype=int)
-        tx_num = len(ch_ids)
-        ping_num = len(self.convert_obj.ping_time)
-        # Order channels based on config because channel ordering from ping_data_dict is not always the same
-        ping_data_channels = self.convert_obj.ping_data_dict['frequency'].keys()
-        ch_idx = [ch_ids.index(ch) for ch in ping_data_channels if ch in ch_ids]
-
-        # Assemble coordinates and data variables
-        ds_backscatter = []
-        if bb:  # complex data (BB or CW)
-            for k in ch_ids:
-                num_transducer_sectors = np.unique(np.array(self.convert_obj.ping_data_dict['n_complex'][k]))
-                if num_transducer_sectors.size > 1:
-                    raise ValueError('Transducer sector number changes in the middle of the file!')
-                else:
-                    num_transducer_sectors = num_transducer_sectors[0]
-                data_shape = self.convert_obj.ping_data_dict['complex'][k].shape
-                data_shape = (data_shape[0], int(data_shape[1]/num_transducer_sectors), num_transducer_sectors)
-                data = np.expand_dims(self.convert_obj.ping_data_dict['complex'][k].reshape(data_shape), axis=0)
-                ds_tmp = xr.Dataset(
-                    {
-                        'backscatter_r': (['frequency', 'ping_time', 'range_bin', 'quadrant'],
-                                          np.real(data),
-                                          {'long_name': 'Real part of backscatter power',
-                                           'units': 'V'}),
-                        'backscatter_i': (['frequency', 'ping_time', 'range_bin', 'quadrant'],
-                                          np.imag(data),
-                                          {'long_name': 'Imaginary part of backscatter power',
-                                           'units': 'V'}),
-                    },
-                    coords={
-                        'frequency': (['frequency'],
-                                      [self.convert_obj.config_datagram['configuration'][k]['transducer_frequency']],
-                                      {'units': 'Hz',
-                                       'long_name': 'Transducer frequency',
-                                       'valid_min': 0.0}),
-                        'ping_time': (['ping_time'], self.convert_obj.ping_time[k],
-                                      {'axis': 'T',
-                                       'calendar': 'gregorian',
-                                       'long_name': 'Timestamp of each ping',
-                                       'standard_name': 'time',
-                                       'units': 'seconds since 1900-01-01'}),
-                        'range_bin': (['range_bin'], np.arange(data_shape[1])),
-                        'quadrant': (['quadrant'], np.arange(num_transducer_sectors)),
-                    }
-                )
-                ds_backscatter.append(ds_tmp)
-
-        else:  # power and angle data (CW)
-            for k in ch_ids:
-                data_shape = self.convert_obj.ping_data_dict['power'][k].shape
-                ds_tmp = xr.Dataset(
-                    {
-                        'backscatter_r': (['frequency', 'ping_time', 'range_bin'],
-                                          np.expand_dims(self.convert_obj.ping_data_dict['power'][k], axis=0),
-                                          {'long_name': 'Backscattering power',
-                                           'units': 'dB'}),
-                        'angle_athwartship': (['frequency', 'ping_time', 'range_bin'],
-                                              np.expand_dims(self.convert_obj.ping_data_dict['angle'][k][:, :, 0],
-                                                             axis=0),
-                                              {'long_name': 'electrical athwartship angle'}),
-                        'angle_alongship': (['frequency', 'ping_time', 'range_bin'],
-                                            np.expand_dims(self.convert_obj.ping_data_dict['angle'][k][:, :, 1],
-                                                           axis=0),
-                                            {'long_name': 'electrical alongship angle'})
-                    },
-                    coords={
-                        'frequency': (['frequency'],
-                                      [self.convert_obj.config_datagram['configuration'][k]['transducer_frequency']],
-                                      {'units': 'Hz',
-                                       'long_name': 'Transducer frequency',
-                                       'valid_min': 0.0}),
-                        'ping_time': (['ping_time'], self.convert_obj.ping_time[k],
-                                      {'axis': 'T',
-                                       'calendar': 'gregorian',
-                                       'long_name': 'Timestamp of each ping',
-                                       'standard_name': 'time',
-                                       'units': 'seconds since 1900-01-01'}),
-                        'range_bin': (['range_bin'], np.arange(data_shape[1])),
-                    }
-                )
-                ds_backscatter.append(ds_tmp)
-
-        # Merge data from all channels
-        ds_merge = xr.merge(ds_backscatter)
 
         # Loop through each transducer for channel-specific variables
+        tx_num = len(ch_ids)
         beam_dict = dict()
         beam_dict['gain_correction'] = np.zeros(shape=(tx_num,), dtype='float32')
         beam_dict['wbt_software_version'] = []
         beam_dict['channel_id'] = []
 
-        params = ['beam_width_alongship', 'beam_width_athwartship', 'beam_width_alongship',
-                  'beam_width_athwartship', 'transducer_alpha_x', 'transducer_alpha_y',
-                  'transducer_alpha_z', 'angle_offset_alongship', 'angle_offset_athwartship',
-                  'angle_sensitivity_alongship', 'angle_sensitivity_athwartship', 'transducer_offset_x',
-                  'transducer_offset_y', 'transducer_offset_z', 'equivalent_beam_angle']
+        params = [
+            'beam_width_alongship',
+            'beam_width_athwartship',
+            'beam_width_alongship',
+            'beam_width_athwartship',
+            'transducer_alpha_x',
+            'transducer_alpha_y',
+            'transducer_alpha_z',
+            'angle_offset_alongship',
+            'angle_offset_athwartship',
+            'angle_sensitivity_alongship',
+            'angle_sensitivity_athwartship',
+            'transducer_offset_x',
+            'transducer_offset_y',
+            'transducer_offset_z',
+            'equivalent_beam_angle'
+        ]
 
         beam_par = defaultdict(lambda: np.zeros(shape=(tx_num,), dtype='float32'))
         c_seq = 0
@@ -275,44 +203,8 @@ class SetGroupsEK80(SetGroupsBase):
             beam_dict['channel_id'].append(c['channel_id'])
             c_seq += 1
 
-        # Stack channels and order axis as: channel, quadrant, ping, range
-        # TODO: @ngkavin: change below to if-else testing the power data and frequency start/end combination
-        if bb:
-            try:
-                freq_start = np.array([self.convert_obj.ping_data_dict['frequency_start'][x][0]
-                                      for x in ch_ids], dtype=int)
-                freq_end = np.array([self.convert_obj.ping_data_dict['frequency_end'][x][0]
-                                    for x in ch_ids], dtype=int)
-            # Exception occurs when instrument records complex power data without
-            # supplying the frequency start and end for every channel
-            except IndexError:
-                freq_start = np.array([config[x].get('transducer_frequency_minimum', np.nan)
-                                       for x in ch_ids], dtype=int)
-                freq_end = np.array([config[x].get('transducer_frequency_maximum', np.nan)
-                                     for x in ch_ids], dtype=int)
-
-        # Match timestamp of each ping in power data with ping_time for each channel
-        # If all channels ping at the same time then ch_indices equals the ping_time
-        ch_indices = np.array(list(self.convert_obj.ch_ping_idx.values()))
-        pulse_length_name = 'pulse_duration' if 'pulse_duration' in self.convert_obj.ping_data_dict else 'pulse_length'
-        ping_params = [pulse_length_name, 'transmit_power', 'sample_interval', 'slope']
-        ping_param_dict = {}
-        for param in ping_params:
-            tmp_arr = np.full((tx_num, ping_num), np.nan)
-            for ch in ch_idx:
-                tmp_arr[ch, ch_indices[ch]] = \
-                    np.array(list(self.convert_obj.ping_data_dict[param].values()))[ch]
-            ping_param_dict[param] = tmp_arr
-
-        # Build other parameters
-        # beam_dict['non_quantitative_processing'] = np.array([0, ] * freq.size, dtype='int32')
-        # -- sample_time_offset is set to 2 for EK60 data, this value is NOT from sample_data['offset']
-        # beam_dict['sample_time_offset'] = np.array([2, ] * freq.size, dtype='int32')
-
-        # Convert np.datetime64 numbers to seconds since 1900-01-01
-        # due to xarray.to_netcdf() error on encoding np.datetime64 objects directly
-        ping_time = (self.convert_obj.ping_time - np.datetime64('1900-01-01T00:00:00')) / np.timedelta64(1, 's')
-
+        # Assemble Dataset for variables indexed by channel only
+        freq = [self.convert_obj.config_datagram['configuration'][k]['transducer_frequency'] for k in ch_ids]
         ds = xr.Dataset(
             {'channel_id': (['frequency'], beam_dict['channel_id']),
              'beamwidth_receive_alongship': (['frequency'], beam_par['beamwidth_receive_major'],
@@ -368,33 +260,6 @@ class SetGroupsEK80(SetGroupsBase):
              'gain_correction': (['frequency'], beam_dict['gain_correction'],
                                  {'long_name': 'Gain correction',
                                   'units': 'dB'}),
-             # TODO: @ngkvain: any reason we are keeping the commented-out variables?
-            #  'non_quantitative_processing': (['frequency'], beam_dict['non_quantitative_processing'],
-            #                                  {'flag_meanings': 'no_non_quantitative_processing',
-            #                                   'flag_values': '0',
-            #                                   'long_name': 'Presence or not of non-quantitative '
-            #                                                'processing applied to the backscattering '
-            #                                                'data (sonar specific)'}),
-             'sample_interval': (['frequency', 'ping_time'], ping_param_dict['sample_interval'],
-                                 {'long_name': 'Interval between recorded raw data samples',
-                                  'units': 's',
-                                  'valid_min': 0.0}),
-            #  'sample_time_offset': (['frequency'], beam_dict['sample_time_offset'],
-            #                         {'long_name': 'Time offset that is subtracted from the timestamp '
-            #                                       'of each sample',
-            #                          'units': 's'}),
-            #  'transmit_bandwidth': (['frequency'], tx_sig['transmit_bandwidth'],
-            #                         {'long_name': 'Nominal bandwidth of transmitted pulse',
-            #                          'units': 'Hz',
-            #                          'valid_min': 0.0}),
-             'transmit_duration_nominal': (['frequency', 'ping_time'], ping_param_dict[pulse_length_name],
-                                           {'long_name': 'Nominal bandwidth of transmitted pulse',
-                                            'units': 's',
-                                            'valid_min': 0.0}),
-             'transmit_power': (['frequency', 'ping_time'], ping_param_dict['transmit_power'],
-                                {'long_name': 'Nominal transmit power',
-                                 'units': 'W',
-                                 'valid_min': 0.0}),
              'transducer_offset_x': (['frequency'], beam_par['transducer_offset_x'],
                                      {'long_name': 'x-axis distance from the platform coordinate system '
                                                    'origin to the sonar transducer',
@@ -407,78 +272,195 @@ class SetGroupsEK80(SetGroupsBase):
                                      {'long_name': 'z-axis distance from the platform coordinate system '
                                                    'origin to the sonar transducer',
                                       'units': 'm'}),
-             'slope': (['frequency', 'ping_time'], ping_param_dict['slope'])},
-            coords={'frequency': (['frequency'], freq,
+             },
+            coords={
+                'frequency': (['frequency'], freq,
                                   {'units': 'Hz',
                                    'long_name': 'Transducer frequency',
                                    'valid_min': 0.0}),
-                    'ping_time': (['ping_time'], ping_time,
-                                  {'axis': 'T',
-                                   'calendar': 'gregorian',
-                                   'long_name': 'Timestamp of each ping',
-                                   'standard_name': 'time',
-                                   'units': 'seconds since 1900-01-01'})},
-            attrs={'beam_mode': 'vertical',
-                   'conversion_equation_t': 'type_3'})
-        # Save broadband backscatter if present
-        if bb:
-            ds_bb = xr.Dataset(
-                {'backscatter_r': (['frequency', 'quadrant', 'ping_time', 'range_bin'], np.real(backscatter)[ch_idx],
-                                   {'long_name': 'Real part of backscatter power',
-                                    'units': 'V'}),
-                 'backscatter_i': (['frequency', 'quadrant', 'ping_time', 'range_bin'], np.imag(backscatter)[ch_idx],
-                                   {'long_name': 'Imaginary part of backscatter power',
-                                    'units': 'V'}),
-                 'frequency_start': (['frequency'], freq_start,
-                                     {'long_name': 'Starting frequency of the transducer',
-                                      'units': 'Hz'}),
-                 'frequency_end': (['frequency'], freq_end,
-                                   {'long_name': 'Ending frequency of the transducer',
-                                    'units': 'Hz'})},
-                coords={'frequency': (['frequency'], freq,
-                                      {'units': 'Hz',
-                                       'long_name': 'Transducer frequency',
-                                       'valid_min': 0.0}),
-                        'ping_time': (['ping_time'], ping_time,
+            },
+            attrs={
+                'beam_mode': 'vertical',
+                'conversion_equation_t': 'type_3'
+            }
+        )
+
+        # TODO: Check convention to see what to do with the variables below:
+        #  'non_quantitative_processing': (['frequency'], beam_dict['non_quantitative_processing'],
+        #                                  {'flag_meanings': 'no_non_quantitative_processing',
+        #                                   'flag_values': '0',
+        #                                   'long_name': 'Presence or not of non-quantitative '
+        #                                                'processing applied to the backscattering '
+        #                                                'data (sonar specific)'}),
+        #  'sample_time_offset': (['frequency'], beam_dict['sample_time_offset'],
+        #                         {'long_name': 'Time offset that is subtracted from the timestamp '
+        #                                       'of each sample',
+        #                          'units': 's'}),
+        #  'transmit_bandwidth': (['frequency'], tx_sig['transmit_bandwidth'],
+        #                         {'long_name': 'Nominal bandwidth of transmitted pulse',
+        #                          'units': 'Hz',
+        #                          'valid_min': 0.0}),
+
+        # Assemble coordinates and data variables
+        ds_backscatter = []
+        if bb:  # complex data (BB or CW)
+            for k in ch_ids:
+                num_transducer_sectors = np.unique(np.array(self.convert_obj.ping_data_dict['n_complex'][k]))
+                if num_transducer_sectors.size > 1:
+                    raise ValueError('Transducer sector number changes in the middle of the file!')
+                else:
+                    num_transducer_sectors = num_transducer_sectors[0]
+                data_shape = self.convert_obj.ping_data_dict['complex'][k].shape
+                data_shape = (data_shape[0], int(data_shape[1]/num_transducer_sectors), num_transducer_sectors)
+                data = self.convert_obj.ping_data_dict['complex'][k].reshape(data_shape)
+
+                # CW data has pulse_duration, BB data has pulse_length
+                if 'pulse_length' in self.convert_obj.ping_data_dict:
+                    pulse_length = self.convert_obj.ping_data_dict['pulse_length'][k]
+                else:
+                    pulse_length = self.convert_obj.ping_data_dict['pulse_duration'][k]
+
+                # Assemble ping by ping data
+                ds_tmp = xr.Dataset(
+                    {
+                        'backscatter_r': (['ping_time', 'range_bin', 'quadrant'],
+                                          np.real(data),
+                                          {'long_name': 'Real part of backscatter power',
+                                           'units': 'V'}),
+                        'backscatter_i': (['ping_time', 'range_bin', 'quadrant'],
+                                          np.imag(data),
+                                          {'long_name': 'Imaginary part of backscatter power',
+                                           'units': 'V'}),
+                        'sample_interval': (['ping_time'],
+                                            self.convert_obj.ping_data_dict['sample_interval'][k],
+                                            {'long_name': 'Interval between recorded raw data samples',
+                                             'units': 's',
+                                             'valid_min': 0.0}),
+                        'transmit_duration_nominal': (['ping_time'],
+                                                      pulse_length,
+                                                      {'long_name': 'Nominal bandwidth of transmitted pulse',
+                                                       'units': 's',
+                                                       'valid_min': 0.0}),
+                        'transmit_power': (['ping_time'],
+                                           self.convert_obj.ping_data_dict['transmit_power'][k],
+                                           {'long_name': 'Nominal transmit power',
+                                            'units': 'W',
+                                            'valid_min': 0.0}),
+                        'slope': (['ping_time'], self.convert_obj.ping_data_dict['slope'][k],),
+                    },
+                    coords={
+                        'ping_time': (['ping_time'], self.convert_obj.ping_time[k],
                                       {'axis': 'T',
                                        'calendar': 'gregorian',
                                        'long_name': 'Timestamp of each ping',
                                        'standard_name': 'time',
                                        'units': 'seconds since 1900-01-01'}),
-                        'quadrant': (['quadrant'], np.arange(max_splits)),
-                        'range_bin': (['range_bin'], np.arange(backscatter.shape[3]))
-                        })
-            ds = xr.merge([ds, ds_bb], combine_attrs='override')
-        # Save continuous wave backscatter
-        else:
-            ds_cw = xr.Dataset(
-                {'backscatter_r': (['frequency', 'ping_time', 'range_bin'],
-                                   self.convert_obj.ping_data_dict['power'][ch_idx],
-                                   {'long_name': 'Backscattering power',
-                                       'units': 'dB'}),
-                 'angle_athwartship': (['frequency', 'ping_time', 'range_bin'],
-                                       self.convert_obj.ping_data_dict['angle'][ch_idx, :, :, 0],
-                                       {'long_name': 'electrical athwartship angle'}),
-                 'angle_alongship': (['frequency', 'ping_time', 'range_bin'],
-                                     self.convert_obj.ping_data_dict['angle'][ch_idx, :, :, 1],
-                                     {'long_name': 'electrical alongship angle'})},
-                coords={'frequency': (['frequency'], freq,
-                                      {'units': 'Hz',
-                                       'long_name': 'Transducer frequency',
-                                       'valid_min': 0.0}),
-                        'ping_time': (['ping_time'], ping_time,
+                        'range_bin': (['range_bin'], np.arange(data_shape[1])),
+                        'quadrant': (['quadrant'], np.arange(num_transducer_sectors)),
+                    }
+                )
+
+                # CW data encoded as complex samples do NOT have frequency_start and frequency_end
+                if 'frequency_end' in self.convert_obj.ping_data_dict.keys():
+                    ds_f_start_end = xr.Dataset(
+                        {
+                            'frequency_start': (['ping_time'],
+                                                self.convert_obj.ping_data_dict['frequency_start'][k],
+                                                {'long_name': 'Starting frequency of the transducer',
+                                                 'units': 'Hz'}),
+                            'frequency_end': (['ping_time'],
+                                              self.convert_obj.ping_data_dict['frequency_end'][k],
+                                              {'long_name': 'Ending frequency of the transducer',
+                                               'units': 'Hz'}),
+
+                        },
+                        coords={
+                            'ping_time': (['ping_time'], self.convert_obj.ping_time[k],
+                                          {'axis': 'T',
+                                           'calendar': 'gregorian',
+                                           'long_name': 'Timestamp of each ping',
+                                           'standard_name': 'time',
+                                           'units': 'seconds since 1900-01-01'}),
+                        }
+                    )
+                    ds_tmp = xr.merge([ds_tmp, ds_f_start_end],
+                                      combine_attrs='override')  # override keeps the Dataset attributes
+
+                # Attach frequency dimension/coordinate
+                ds_tmp = ds_tmp.expand_dims(
+                    {'frequency': [self.convert_obj.config_datagram['configuration'][k]['transducer_frequency']]})
+                ds_tmp['frequency'] = ds_tmp['frequency'].assign_attrs(
+                    units='Hz',
+                    long_name='Transducer frequency',
+                    valid_min=0.0,
+                )
+                ds_backscatter.append(ds_tmp)
+
+        else:  # power and angle data (CW)
+            for k in ch_ids:
+                data_shape = self.convert_obj.ping_data_dict['power'][k].shape
+                ds_tmp = xr.Dataset(
+                    {
+                        'backscatter_r': (['ping_time', 'range_bin'],
+                                          self.convert_obj.ping_data_dict['power'][k],
+                                          {'long_name': 'Backscattering power',
+                                           'units': 'dB'}),
+                        'angle_athwartship': (['ping_time', 'range_bin'],
+                                              self.convert_obj.ping_data_dict['angle'][k][:, :, 0],
+                                              {'long_name': 'electrical athwartship angle'}),
+                        'angle_alongship': (['ping_time', 'range_bin'],
+                                            self.convert_obj.ping_data_dict['angle'][k][:, :, 1],
+                                            {'long_name': 'electrical alongship angle'}),
+                        'sample_interval': (['ping_time'],
+                                            self.convert_obj.ping_data_dict['sample_interval'][k],
+                                            {'long_name': 'Interval between recorded raw data samples',
+                                             'units': 's',
+                                             'valid_min': 0.0}),
+                        'transmit_duration_nominal': (['ping_time'],
+                                                      self.convert_obj.ping_data_dict['pulse_duration'][k],
+                                                      {'long_name': 'Nominal bandwidth of transmitted pulse',
+                                                       'units': 's',
+                                                       'valid_min': 0.0}),
+                        'transmit_power': (['ping_time'],
+                                           self.convert_obj.ping_data_dict['transmit_power'][k],
+                                           {'long_name': 'Nominal transmit power',
+                                            'units': 'W',
+                                            'valid_min': 0.0}),
+                        'slope': (['ping_time'],
+                                  self.convert_obj.ping_data_dict['slope'][k]),
+                    },
+                    coords={
+                        'ping_time': (['ping_time'], self.convert_obj.ping_time[k],
                                       {'axis': 'T',
                                        'calendar': 'gregorian',
                                        'long_name': 'Timestamp of each ping',
                                        'standard_name': 'time',
                                        'units': 'seconds since 1900-01-01'}),
-                        'range_bin': (['range_bin'], np.arange(self.convert_obj.ping_data_dict['power'].shape[2]))
-                        })
-            ds = xr.merge([ds, ds_cw], combine_attrs='override')
+                        'range_bin': (['range_bin'], np.arange(data_shape[1])),
+                    }
+                )
+                # Attach frequency dimension/coordinate
+                ds_tmp = ds_tmp.expand_dims(
+                    {'frequency': [self.convert_obj.config_datagram['configuration'][k]['transducer_frequency']]})
+                ds_tmp['frequency'] = ds_tmp['frequency'].assign_attrs(
+                    units='Hz',
+                    long_name='Transducer frequency',
+                    valid_min=0.0,
+                )
+                ds_backscatter.append(ds_tmp)
+
+        # Merge data from all channels
+        ds_merge = xr.merge(ds_backscatter)
+        ds = xr.merge([ds, ds_merge], combine_attrs='override')  # override keeps the Dataset attributes
 
         # Below are specific to Simrad .raw files
         if 'wbt_software_version' in beam_dict:
             ds['wbt_software_version'] = ('frequency', beam_dict['wbt_software_version'])
+
+        # Convert np.datetime64 numbers to seconds since 1900-01-01
+        #  due to xarray.to_netcdf() error on encoding np.datetime64 objects directly
+        ds['ping_time'] = (ds['ping_time'] - np.datetime64('1900-01-01T00:00:00')) / np.timedelta64(1, 's')
+
         # Save to file
         if self.save_ext == '.nc':
             nc_encoding = {var: self.NETCDF_COMPRESSION_SETTINGS for var in ds.data_vars} if self.compress else {}


### PR DESCRIPTION
Summary of changes:
- Changed `ping_time` to be dict indexed by channel_id to facilitate using xarray.Dataset.merge to combine ping-by-ping data with potentially disparate `ping_time`, including adding `pad_shorter_ping` under ParseEK80 to replace `_rectangularize`.
- Cleaned up `set_beam` for EK80, including taking care of code related to `n_complex`.

@ngkavin : Please look into the error in the test file `raw_path_2_f = './echopype/test_data/ek80/2019118 group2survey-D20191214-T081342.raw'`. There's something not quite right about `ch_ids` passed into `set_beam`. 

It is likely due to my removal of one of the ch_id cleaning functions and attributes from the operation (self.recorded_ch_ids and _clean_channel). The checking to get rid of channels not containing data can most likely be absorbed into `_sort_ch_bb_cw`. All other files converted properly.  

I suspect that `ch_ids` and `recorded_ch_ids` are not needed anymore with the PR change of how data from different channels are combined.
