### PR TITLE
Hard pin s3fs for now to make tests work

### DIFF
--- a/.ci_helpers/py3.7.yaml
+++ b/.ci_helpers/py3.7.yaml
@@ -15,5 +15,5 @@ dependencies:
   - fsspec==0.8.7
   - requests
   - aiohttp
-  - s3fs>=0.5
+  - s3fs==0.5.2
   - mamba

--- a/.ci_helpers/py3.8.yaml
+++ b/.ci_helpers/py3.8.yaml
@@ -15,5 +15,5 @@ dependencies:
   - fsspec==0.8.7
   - requests
   - aiohttp
-  - s3fs>=0.5
+  - s3fs==0.5.2
   - mamba

--- a/.ci_helpers/py3.9.yaml
+++ b/.ci_helpers/py3.9.yaml
@@ -15,5 +15,5 @@ dependencies:
   - fsspec==0.8.7
   - requests
   - aiohttp
-  - s3fs>=0.5
+  - s3fs==0.5.2
   - mamba


### PR DESCRIPTION
Right now `s3fs` version `0.6.0` is installed in CI and this is not compatible with `fsspec` version `0.8.7` so I'm hard pinning for now.